### PR TITLE
impl Send + Sync

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,6 +49,13 @@ pub struct MagicBuffer {
     mask: usize,
 }
 
+// SAFETY: Memory mappings are not tied to a thread, so they can be sent
+// across thread boundaries safely.
+unsafe impl Send for MagicBuffer {}
+
+// SAFETY: There is no interior mutability.
+unsafe impl Sync for MagicBuffer {}
+
 /// [`MagicBuffer`] provides a ring buffer implementation that
 /// can deref into a contiguous slice from any offset wrapping
 /// around the buffer.


### PR DESCRIPTION
The auto-traits get disabled because there's a raw pointer in MagicBuffer, but to the best of my knowledge, it is in fact perfectly safe to share and send between threads.